### PR TITLE
Fix broken example and improve SnapSearchBarController's customization ability

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -413,7 +413,7 @@ class ViewController: UIViewController {
         c.canBeTurnedOnAndOff = false
         c.isTappable = true
         c.margin = UIEdgeInsets(top: 11.0, left: 1.0, bottom: 11.0, right: 0.0)
-        c.labelInset = UIEdgeInsetsMake(10.0, 8.0, 7.0, 0.0)
+        c.labelInset = UIEdgeInsetsMake(7.0, 8.0, 7.0, 0.0)
         c.buttonInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 10.0)
         
         var onState = ButtonStateConfiguration()

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -118,7 +118,6 @@ class ViewController: UIViewController {
         constraints.append(NSLayoutConstraint(expressionFormat: "self.height = 44", parameters: dict))
         view.addConstraints(constraints)
 
-
         tagBarViewController = SnapTagsCollectionViewController()
         tagBarViewController.sizer = sizer
         tagBarViewController.configuration = tagBarViewConfig()
@@ -141,10 +140,9 @@ class ViewController: UIViewController {
 
         constraints = [NSLayoutConstraint]()
         dict = ["self": tagBarViewController.view, "super": tagScrollView]
-        constraints.append(NSLayoutConstraint(expressionFormat: "self.width >= \(sizeForTags.width)", parameters: dict))
-        constraints.append(NSLayoutConstraint(expressionFormat: "self.height >= \(sizeForTags.height + (tagBarViewController.configuration.verticalMargin * 2))", parameters: dict))
+        constraints.append(NSLayoutConstraint(expressionFormat: "self.width >= \(round(sizeForTags.width) + (tagBarViewController.configuration.horizontalMargin * 2))", parameters: dict))
+        constraints.append(NSLayoutConstraint(expressionFormat: "self.height >= \(round(sizeForTags.height) + (tagBarViewController.configuration.verticalMargin * 2))", parameters: dict))
         tagScrollView.addConstraints(constraints)
-
 
     }
 
@@ -254,7 +252,7 @@ class ViewController: UIViewController {
         c.font = UIFont.boldWithSize(13.0)
         c.canBeTurnedOnAndOff = true
         c.margin = UIEdgeInsetsZero
-        c.labelInset = UIEdgeInsetsMake(8.0, 8.0, 5.0, 8.0)
+        c.labelInset = UIEdgeInsets(top: 6.5, left: 8.0, bottom: 6.5, right: 8.0)
 
         var onState = ButtonStateConfiguration()
         onState.buttonImage = UIImage.SnapTagsViewAssets.YellowCloseButton.image
@@ -304,8 +302,8 @@ class ViewController: UIViewController {
         c.font = UIFont.boldWithSize(13.0)
         c.canBeTurnedOnAndOff = false
         c.margin = UIEdgeInsetsZero
-        c.labelInset = UIEdgeInsetsMake(8.0, 8.0, 5.0, 0.0)
-        c.buttonInset = UIEdgeInsetsMake(0.0, 8.0, 0.0, 10.0)
+        c.labelInset = UIEdgeInsets(top: 6.5, left: 8.0, bottom: 6.5, right: 0.0)
+        c.buttonInset = UIEdgeInsets(top: 0.0, left: 8.0, bottom: 0.0, right: 10.0)
         c.isTappable = true
 
         var onState = ButtonStateConfiguration()
@@ -356,8 +354,8 @@ class ViewController: UIViewController {
         c.font = UIFont.boldWithSize(13.0)
         c.canBeTurnedOnAndOff = true
         c.margin = UIEdgeInsetsZero
-        c.labelInset = UIEdgeInsetsMake(8.0, 8.0, 5.0, 0.0)
-        c.buttonInset = UIEdgeInsetsMake(0.0, 8.0, 0.0, 10.0)
+        c.labelInset = UIEdgeInsets(top: 6.5, left: 8.0, bottom: 6.5, right: 0.0)
+        c.buttonInset = UIEdgeInsets(top: 0.0, left: 8.0, bottom: 0.0, right: 10.0)
         c.isTappable = true
 
         var onState = ButtonStateConfiguration()
@@ -398,7 +396,7 @@ class ViewController: UIViewController {
         config.contentHeight = 36.0
         config.alignment = .Left
         config.scrollDirection = .Horizontal
-        config.padding = UIEdgeInsetsMake(3.0, 0.0, 3.0, 66.0)
+        config.padding = UIEdgeInsets(top: 3.0, left: 0.0, bottom: 3.0, right: 66.0)
 
         return config
     }
@@ -464,8 +462,7 @@ class ViewController: UIViewController {
         c.font = UIFont.boldWithSize(13.0)
         c.canBeTurnedOnAndOff = false
         c.margin = UIEdgeInsetsZero
-        c.labelInset = UIEdgeInsetsMake(8.0, 8.0, 5.0, 0.0)
-        c.buttonInset = UIEdgeInsetsMake(0.0, 8.0, 0.0, 10.0)
+        c.labelInset = UIEdgeInsets(top: 6.5, left: 8.0, bottom: 6.5, right: 8.0)
 
         var onState = ButtonStateConfiguration()
         onState.backgroundColor = UIColor.whiteColor()

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -102,7 +102,6 @@ class ViewController: UIViewController {
 
         contentStackView.insertArrangedSubview(searchBarController.view, atIndex: index)
 
-
     }
 
 
@@ -394,8 +393,8 @@ class ViewController: UIViewController {
 
         var config = SnapTagsViewConfiguration()
         config.spacing = 5.0
-        config.horizontalMargin = 0.0
-        config.verticalMargin = 0.0
+        config.horizontalMargin = 11.0
+        config.verticalMargin = 4.0
         config.contentHeight = 36.0
         config.alignment = .Left
         config.scrollDirection = .Horizontal
@@ -413,7 +412,7 @@ class ViewController: UIViewController {
         c.canBeTurnedOnAndOff = false
         c.isTappable = true
         c.margin = UIEdgeInsets(top: 11.0, left: 1.0, bottom: 11.0, right: 0.0)
-        c.labelInset = UIEdgeInsetsMake(7.0, 8.0, 7.0, 0.0)
+        c.labelInset = UIEdgeInsets(top: 7.0, left: 8.0, bottom: 7.0, right: 0.0)
         c.buttonInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 10.0)
         
         var onState = ButtonStateConfiguration()

--- a/Podfile
+++ b/Podfile
@@ -18,5 +18,5 @@ target 'SnapTagsViewTests' do
 end
 
 target 'Example' do
+  pod 'SnapTagsView', :path => '.'
 end
-

--- a/SnapTagsView/SnapSearchBarController.swift
+++ b/SnapTagsView/SnapSearchBarController.swift
@@ -65,6 +65,7 @@ public class SnapSearchBarController : UIViewController {
         configuration.alignment = .Natural
         tagsVc.configuration = configuration
         tagsVc.buttonConfiguration = buttonConfiguration
+        tagsVc.handlesViewConfigurationMargins = false
 
         searchBar.delegate = self
         searchBar.setNeedsLayout()
@@ -94,7 +95,10 @@ public class SnapSearchBarController : UIViewController {
         searchTextField.tintColor = UIColor.roseColor()
         self.searchTextField = searchTextField
 
-        tagScrollView = SnapTagsHorizontalScrollView.setupTagScrollViewAsSubviewOf(searchBar)
+        let hMargin = configuration.horizontalMargin
+        let vMargin = configuration.verticalMargin
+        
+        tagScrollView = SnapTagsHorizontalScrollView.setupTagScrollViewAsSubviewOf(searchBar, horizontalMargin: hMargin, verticalMargin: vMargin)
 
         self.addChildViewController(tagsVc)
         tagScrollView?.addSubview(tagsVc.view)

--- a/SnapTagsView/SnapTagsCollectionViewController.swift
+++ b/SnapTagsView/SnapTagsCollectionViewController.swift
@@ -13,6 +13,7 @@ public class SnapTagsCollectionViewController: UIViewController {
     public weak var delegate : SnapTagsButtonDelegate?
 
     internal var collectionView : UICollectionView?
+    internal var handlesViewConfigurationMargins = true
 
     public lazy var sizer = SnapTextWidthSizers()
 
@@ -96,6 +97,13 @@ public class SnapTagsCollectionViewController: UIViewController {
         
         self.view.translatesAutoresizingMaskIntoConstraints = false
         collectionView.translatesAutoresizingMaskIntoConstraints = false
+
+        var configuration = self.configuration
+        if !handlesViewConfigurationMargins {
+            configuration.horizontalMargin = 0.0
+            configuration.verticalMargin = 0.0
+        }
+
         let metrics = [
             "hMargin": configuration.horizontalMargin,
             "vMargin": configuration.verticalMargin,

--- a/SnapTagsView/SnapTagsHorizontalScrollView.swift
+++ b/SnapTagsView/SnapTagsHorizontalScrollView.swift
@@ -22,17 +22,17 @@ public class SnapTagsHorizontalScrollView : UIViewController {
         tagScrollView.translatesAutoresizingMaskIntoConstraints = false
     }
 
-    public static func setupTagScrollViewAsSubviewOf(view: UIView) -> UIScrollView {
+    public static func setupTagScrollViewAsSubviewOf(view: UIView, horizontalMargin: CGFloat = 3, verticalMargin: CGFloat = 4) -> UIScrollView {
         let tagScrollView = SnapTagsHorizontalScrollView.createTagScrollView()
         setupTagScrollView(tagScrollView)
         view.addSubview(tagScrollView)
 
         var constraints = [NSLayoutConstraint]()
         let dict : [String:UIView] = ["self": tagScrollView, "super": view]
-        constraints.append(NSLayoutConstraint(expressionFormat: "self.left = super.left + 3", parameters: dict))
-        constraints.append(NSLayoutConstraint(expressionFormat: "self.right = super.right - 3", parameters: dict))
-        constraints.append(NSLayoutConstraint(expressionFormat: "self.top = super.top + 4", parameters: dict))
-        constraints.append(NSLayoutConstraint(expressionFormat: "self.bottom = super.bottom - 4", parameters: dict))
+        constraints.append(NSLayoutConstraint(expressionFormat: "self.left = super.left + \(horizontalMargin)", parameters: dict))
+        constraints.append(NSLayoutConstraint(expressionFormat: "self.right = super.right - \(horizontalMargin)", parameters: dict))
+        constraints.append(NSLayoutConstraint(expressionFormat: "self.top = super.top + \(verticalMargin)", parameters: dict))
+        constraints.append(NSLayoutConstraint(expressionFormat: "self.bottom = super.bottom - \(verticalMargin)", parameters: dict))
         view.addConstraints(constraints)
         return tagScrollView
     }


### PR DESCRIPTION
Instead of applying margins on SnapTagsCollectionViewController’s
collectionView, which scroll with the search bar content, the margins
are applied on the search bar itself.
